### PR TITLE
Minor changes to some policies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help improve the project
-title: A bug!
+title: A Bug?
 labels: bug, enhancement
 assignees: JustHm228
 
@@ -9,9 +9,9 @@ assignees: JustHm228
 
 ## Bug
 
-A description of your bug.
+A short (or not) description of your bug.
 
 ## Example
 
-Examples of bug and how to reproduce.
-Try to write as detailed as you can.
+Examples of your bug and how to reproduce it.
+Please try to write it as detailed as you can if you want to avoid unnecessary questions from maintainer(s).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for the project
-title: A new feature!
+title: A new Feature!
 labels: enhancement
 assignees: JustHm228
 
@@ -10,3 +10,4 @@ assignees: JustHm228
 ## Suggestion
 
 What do you want to suggest?
+Try to write as detailed as you can if you want to avoid unnecessary questions from maintainer(s).

--- a/.github/ISSUE_TEMPLATE/help-request.md
+++ b/.github/ISSUE_TEMPLATE/help-request.md
@@ -1,7 +1,7 @@
 ---
 name: Help request
 about: Ask a question if you need help
-title: Help!
+title: Help Me!
 labels: question
 assignees: JustHm228
 
@@ -9,4 +9,6 @@ assignees: JustHm228
 
 ## Help
 
-Your question here.
+Enter your question here.
+But remember that the question is the same as the answer!
+So, please, ask specific questions and when you will receive a specific answer.

--- a/.github/ISSUE_TEMPLATE/vulnerability-report.md
+++ b/.github/ISSUE_TEMPLATE/vulnerability-report.md
@@ -1,7 +1,7 @@
 ---
 name: Vulnerability report
 about: Create a report to improve security
-title: A vulnerability!
+title: A Vulnerability Report!
 labels: insecure
 assignees: JustHm228
 
@@ -9,9 +9,9 @@ assignees: JustHm228
 
 ## Vulnerability
 
-A description of your vulnerability.
+A short (or not) description of your vulnerability.
 
 ## Example
 
-Examples of your vulnerability and how to reproduce.
-Try to write as detailed as you can.
+Examples of your vulnerability and how to reproduce it.
+Please try to write as detailed as you can if you want to avoid unnecessary questions from maintainer(s).

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1089,9 +1089,30 @@
     <inspection_tool class="HtmlRequiredTitleElement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HtmlUnknownAnchorTarget" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
     <inspection_tool class="HtmlUnknownBooleanAttribute" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="6">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
     <inspection_tool class="HtmlUnknownTarget" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="HtmlWrongAttributeValue" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="I18nForm" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # JLatenter
 
----
-
-**JLatenter** is a small implementation of latent typing in Java which uses dynamic proxies to redirect method calls from an interface stub to the real object.
+**JLatenter** is a small implementation of latent typing in Java which
+uses [dynamic proxies](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/reflect/Proxy.html) to
+redirect method calls from an interface stub to the real object.
 **I don't know how original this thing is**, I just came up with this implementation of this idea and decided to do it because why not.
 
 ## How to Use
 
----
-
-There's a little background here. I studied the Java programming language for almost 2 years, mostly using the Internet.
-In addition to just studying the theory, I simultaneously wrote my programs, encountered problems and found answers to them on StackOverflow or, in the end, in various English-language articles.
+There's a little background here.
+I studied the Java programming language for almost 2 years, mostly using the Internet.
+In addition to just studying the theory, I simultaneously wrote my programs, encountered problems and found answers to
+them on [StackOverflow](https://stackoverflow.com) or, in the end, in various English-language articles.
 Over the course of my time, I have visited many sites, many of which you may not have even heard of.
 But besides this, I also read books.
 One of them was Bruce Eckel's book "Thinking in Java", 4th Edition (an excellent book, by the way, I recommend reading it - it will be at least interesting).
@@ -18,7 +18,9 @@ I first saw the idea of implementing latent typing in Java there.
 But I wasn't interested in it.
 Later, when I had already studied Java to a level acceptable to me personally, I began to write various software for myself, which I might later post on GitHub, and, in fact, I started GitHub itself - at a minimum, it definitely won't be superfluous.
 But then, I simply ran out of ideas, and my study began.
-And then, during a regular walk, the idea of combining dynamic proxies and latent typing from Python came to my mind.
+And then, during a regular walk, the idea of
+combining [dynamic proxies](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/reflect/Proxy.html)
+and latent typing from Python came to my mind.
 This is how this implementation was born.
 
 ---
@@ -59,7 +61,7 @@ import static com.github.justhm228.jlatenter.latent.Latent.*;
 
 public class Main {
 
-	public static void main(String[] args) throws LatentException { // <-- If something went wrong
+	public static void main(String[] args) throws LatentException { // <-- If something went wrong (`LatentException` is unchecked, so you don't need to handle it always)
 
 		final Object instance = new Task(); // <-- Losing the type
 
@@ -90,8 +92,8 @@ The class contains 3 overloaded methods:
 `as()` takes as the first argument the object whose method you want to call, and the second argument in the two overloaded versions is different:
 
 - In the first version it's a reference to the interface as which you want to represent the object
-- In the second version it's an object that implements a single interface, as which an object can be represented *(it's
-  a failed experiment, please forget about its existence)*.
+- ~~In the second version it's an object that implements a single interface, as which an object can be
+  represented *(it's a failed experiment, please forget about its existence)*.~~
 
 but return value is always the same - a "shadow" of the passed object.
 The `isShadowed()` method accepts a single object and returns `true` if the object is the "shadow" of another object, and `false` if not.
@@ -140,13 +142,11 @@ It's very short, isn't it?
 Also, if you take into account that you can use static import to call the `as()` method (like in the examples), it turns
 out that you can call the method you need in almost one line (possibly even without creating a new interface).
 **But note that the garbage collector won't be able to destroy the original object while its "shadow" exists, because it
-references original directly, so take that into account *(I won't fix this due to other problems caused by such fixes)*.
+references original directly, so take that into account _(I won't fix this due to other problems caused by such fixes)_.
 **
 I hope I explained clearly.
 
 ## Examples
-
----
 
 I'd write more examples, but... I don't have enough time for this, so for now let there be only 1 example:
 
@@ -179,8 +179,6 @@ public class Example {
 Just wait until I got the time, okay?
 
 ## Future Plans
-
----
 
 I really wanted to finish at 0.1-build.1 initially, but then I realized that I could turn this spontaneous idea into something more and add a little more functionality.
 But first, I need to add more stub interfaces.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,5 @@
 # Security Policy
 
-## Warning
-
-I, of course, don't think that there could be vulnerabilities in such a project, but it's better to be prepared in advance than to prepare in a hurry later.
-Actually, this warning itself is intended to inform you that if you have opened this file, then you are most likely paranoid and you need to get a good night's sleep.
-**Stay healthy! ❤**
-
 ## Supported Versions
 
 Currently there's no a stable version you can use without bugs but the most stable now is... 0.1-build.1 due to it's the only version you can use now.
@@ -19,5 +13,3 @@ Yeah, that's very few... but it's more than nothing so wait until I publish a ne
 
 To report a vulnerability (if you somehow find it in such a small project, of course) you just need to create a new issue under the template "Vulnerability report" and describe what is it and how to reproduce it.
 It's very simple.
-
-P.S. Let me remind you that if you opened this file, then most likely you have paranoia and problems sleeping. Please get some sleep! **Stay healthly! ❤**

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Latent.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Latent.java
@@ -30,6 +30,7 @@ public final class Latent {
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_, _ -> _", pure = true)
+	@Deprecated(since = "0.1-build.2")
 	public static @NotNull(exception = NullPointerException.class) Object as(@NotNull(value = "The specified latent instance is null!") final Object instance, @NotNull(value = "The specified cast type is null!", exception = NullPointerException.class) final Object type) throws Error, NullPointerException, IllegalArgumentException {
 
 		requireNonNull(instance, "The specified latent instance is null!");


### PR DESCRIPTION
A second overloaded version of the `Latent.as()` method
is now deprecated due to the experiment is failed.
Slightly updated security policy. The format style of
`README.md` has been changed and the description of
the second overloaded version of `Latent.as()` method is
strikethrough now. That's all.
