### PR TITLE
Fix `finalize()` implementation

### DIFF
--- a/src/main/java/com/github/justhm228/jlatenter/latent/Gettable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Gettable.java
@@ -64,7 +64,7 @@ public interface Gettable {
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract(value = " -> _") // <-- "pure" is unknown
-	@Shadow()
-	// <-- Just a stub method
-	Object get() throws Error, LatentException; // TODO: 09.09.2023 Expand this interface with other methods (like Formattable, Buildable, Puttable).
+	@Shadow() // <-- Just a stub method
+	// TODO: 09.09.2023 Expand this interface with other methods (like Formattable, Buildable, Puttable):
+	Object get() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Latent.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Latent.java
@@ -490,6 +490,7 @@ public final class Latent {
 
 			} catch (@NotNull(exception = NullPointerException.class) final PrivilegedActionException notFound) {
 
+				// TODO: 18.09.2023 Try to get rid of this:
 				if (Objects.equals(method.getDeclaringClass(), Object.class)) {
 
 					switch (method.getName()) {
@@ -562,7 +563,10 @@ public final class Latent {
 							}
 						}
 
-						case "finalize" -> {}
+						case "finalize" -> {
+
+							return null;
+						}
 					}
 				}
 

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Puttable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Puttable.java
@@ -66,7 +66,7 @@ public interface Puttable {
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
-	@Shadow()
-	// <-- Just a stub method
-	void put() throws Error, LatentException; // TODO: 09.09.2023 Expand this interface with other methods (like Formattable, Buildable, Gettable).
+	@Shadow() // <-- Just a stub method
+	// TODO: 09.09.2023 Expand this interface with other methods (like Formattable, Buildable, Gettable):
+	void put() throws Error, LatentException;
 }


### PR DESCRIPTION
Fix the `finalize()` method proxied implementation and
fix some other issues caused by the previous commit.
