### PR TITLE
Mark all exceptions with `NotNull`

### DIFF
--- a/src/main/java/com/github/justhm228/jlatenter/latent/Latent.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Latent.java
@@ -552,7 +552,7 @@ public final class Latent {
 										proxy.getClass().getTypeName()
 								);
 
-							} catch (final CloneNotSupportedException unsupported) {
+							} catch (@NotNull(exception = NullPointerException.class) final CloneNotSupportedException unsupported) {
 
 								throw new LatentTargetException(
 


### PR DESCRIPTION
Mark all unannotated exceptions in `catch` blocks with
`NotNull` due to my coding style.
