### PR TITLE
Fix module issues with `exports`

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,8 +3,8 @@ module jlatenter.base {
 	requires java.base;
 	requires static org.jetbrains.annotations;
 
-	exports com.github.justhm228.jlatenter.base to jlatenter.test;
-	exports com.github.justhm228.jlatenter.latent to jlatenter.test;
+	exports com.github.justhm228.jlatenter.base;
+	exports com.github.justhm228.jlatenter.latent;
 
 	opens com.github.justhm228.jlatenter.base to jlatenter.test;
 	opens com.github.justhm228.jlatenter.latent to jlatenter.test;


### PR DESCRIPTION
Export every class to every module that added
it in dependencies (not only to `jlatenter.test`).
