### PR TITLE
Move all stub interfaces to another package

### DIFF
--- a/src/main/java/com/github/justhm228/jlatenter/latent/Buildable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Buildable.java
@@ -30,15 +30,18 @@ import java.lang.*;
 
 @AvailableSince("0.1-build.1")
 @NonExtendable()
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public sealed interface Buildable<T extends Buildable<T>>
-		permits Buildable.XBuildable, Buildable.SelfBuildable, Buildable.GenericBuildable, Buildable.SelfBuildableC,
+		permits com.github.justhm228.jlatenter.latent.stub.Buildable, Buildable.XBuildable, Buildable.SelfBuildable,
+		        Buildable.GenericBuildable, Buildable.SelfBuildableC,
 		        Buildable.GenericBuildableC {
 
 	@AvailableSince("0.1-build.1")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
+	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<XBuildable> buildX() throws Error {
 
@@ -49,6 +52,7 @@ public sealed interface Buildable<T extends Buildable<T>>
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
+	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<SelfBuildable> buildSelf() throws Error {
 
@@ -59,6 +63,7 @@ public sealed interface Buildable<T extends Buildable<T>>
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
+	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<GenericBuildable> buildGeneric() throws Error {
 
@@ -69,6 +74,7 @@ public sealed interface Buildable<T extends Buildable<T>>
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
+	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<SelfBuildableC> buildSelfC() throws Error {
 
@@ -79,6 +85,7 @@ public sealed interface Buildable<T extends Buildable<T>>
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
+	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<GenericBuildableC> buildGenericC() throws Error {
 

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Drawable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Drawable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Drawable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into account
+ * that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that they're all
+ * stored in a package designed specifically for the "general" implementation (not for "extended"). This error could
+ * lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number is
+ * estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in the
+ * Java programming language, and 2.) it contradicts the original basis for which these particular classes were combined
+ * into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this problem it was
+ * decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward compatibility,
+ * it was decided not to move all the classes in the usual sense of the word, but simply copy them there and inherit
+ * them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}. Further use of these
+ * {@link Deprecated deprecated} classes in newer code is highly discouraged, because maintaining backward compatibility
+ * with one single pre-release 0.1-build.1 isn't such a priority, which means that in one of the future releases these
+ * classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Drawable {
 
@@ -51,13 +69,31 @@ public interface Drawable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Drawable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Drawable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Drawable#draw()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void draw() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Forwardable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Forwardable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Forwardable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into account
+ * that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that they're all
+ * stored in a package designed specifically for the "general" implementation (not for "extended"). This error could
+ * lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number is
+ * estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in the
+ * Java programming language, and 2.) it contradicts the original basis for which these particular classes were combined
+ * into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this problem it was
+ * decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward compatibility,
+ * it was decided not to move all the classes in the usual sense of the word, but simply copy them there and inherit
+ * them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}. Further use of these
+ * {@link Deprecated deprecated} classes in newer code is highly discouraged, because maintaining backward compatibility
+ * with one single pre-release 0.1-build.1 isn't such a priority, which means that in one of the future releases these
+ * classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Forwardable {
 
@@ -51,13 +69,31 @@ public interface Forwardable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Forwardable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Forwardable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Forwardable#forward()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void forward() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Gettable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Gettable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Gettable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into account
+ * that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that they're all
+ * stored in a package designed specifically for the "general" implementation (not for "extended"). This error could
+ * lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number is
+ * estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in the
+ * Java programming language, and 2.) it contradicts the original basis for which these particular classes were combined
+ * into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this problem it was
+ * decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward compatibility,
+ * it was decided not to move all the classes in the usual sense of the word, but simply copy them there and inherit
+ * them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}. Further use of these
+ * {@link Deprecated deprecated} classes in newer code is highly discouraged, because maintaining backward compatibility
+ * with one single pre-release 0.1-build.1 isn't such a priority, which means that in one of the future releases these
+ * classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Gettable {
 
@@ -53,13 +71,31 @@ public interface Gettable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Gettable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Gettable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Gettable#get()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract(" -> _") // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	Object get() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Paintable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Paintable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Paintable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into account
+ * that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that they're all
+ * stored in a package designed specifically for the "general" implementation (not for "extended"). This error could
+ * lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number is
+ * estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in the
+ * Java programming language, and 2.) it contradicts the original basis for which these particular classes were combined
+ * into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this problem it was
+ * decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward compatibility,
+ * it was decided not to move all the classes in the usual sense of the word, but simply copy them there and inherit
+ * them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}. Further use of these
+ * {@link Deprecated deprecated} classes in newer code is highly discouraged, because maintaining backward compatibility
+ * with one single pre-release 0.1-build.1 isn't such a priority, which means that in one of the future releases these
+ * classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Paintable {
 
@@ -51,13 +69,31 @@ public interface Paintable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Paintable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Paintable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Paintable#paint()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void paint() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Pausable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Pausable.java
@@ -34,7 +34,24 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Pausable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into account
+ * that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that they're all
+ * stored in a package designed specifically for the "general" implementation (not for "extended"). This error could
+ * lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number is
+ * estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in the
+ * Java programming language, and 2.) it contradicts the original basis for which these particular classes were combined
+ * into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this problem it was
+ * decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward compatibility,
+ * it was decided not to move all the classes in the usual sense of the word, but simply copy them there and inherit
+ * them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}. Further use of these
+ * {@link Deprecated deprecated} classes in newer code is highly discouraged, because maintaining backward compatibility
+ * with one single pre-release 0.1-build.1 isn't such a priority, which means that in one of the future releases these
+ * classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
@@ -51,13 +68,31 @@ public interface Pausable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Pausable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Pausable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Pausable#pause()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
-	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Shadow()
+	// <-- It's just a stub method
 	void pause() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Puttable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Puttable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Puttable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+ * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+ * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+ * error could lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+ * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+ * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+ * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+ * problem it was decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+ * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+ * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+ * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+ * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+ * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Puttable {
 
@@ -53,13 +71,31 @@ public interface Puttable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Puttable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Puttable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Puttable#put()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void put() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Renderable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Renderable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Renderable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+ * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+ * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+ * error could lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+ * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+ * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+ * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+ * problem it was decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+ * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+ * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+ * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+ * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+ * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Renderable {
 
@@ -51,13 +69,31 @@ public interface Renderable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Renderable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Renderable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Renderable#render()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void render() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Startable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Startable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Startable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+ * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+ * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+ * error could lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+ * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+ * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+ * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+ * problem it was decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+ * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+ * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+ * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+ * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+ * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Startable {
 
@@ -51,13 +69,31 @@ public interface Startable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Startable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Startable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Startable#start()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void start() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Steppable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Steppable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Steppable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+ * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+ * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+ * error could lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+ * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+ * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+ * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+ * problem it was decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+ * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+ * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+ * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+ * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+ * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Steppable {
 
@@ -51,13 +69,31 @@ public interface Steppable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Steppable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Steppable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Steppable#step()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void step() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/Stoppable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/Stoppable.java
@@ -34,13 +34,31 @@ import java.lang.*;
  *
  * @author JustHuman228
  * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.stub.Stoppable
  * @since 0.1-build.1
+ * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+ * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+ * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+ * error could lead to the fact that, in the future, there'll be more classes in the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+ * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+ * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+ * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+ * problem it was decided to move all {@link Shadow stub} interfaces from the
+ * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+ * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+ * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+ * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+ * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+ * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+ * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
  */
 @AvailableSince("0.1-build.1")
 @NonExtendable() // <-- Shouldn't be implemented!
 @Blocking() // <-- Potentially blocking context!
 @FunctionalInterface()
 @Shadow() // <-- Just a stub interface
+@Deprecated(since = "0.1-build.2")
 @SuppressWarnings({ "suppress", "warningToken" })
 public interface Stoppable {
 
@@ -51,13 +69,31 @@ public interface Stoppable {
 	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
 	 * @see Stoppable
 	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.stub.Stoppable
+	 * @see com.github.justhm228.jlatenter.latent.stub.Stoppable#stop()
 	 * @since 0.1-build.1
+	 * @deprecated Due to an error made when planning the project structure, the final structure didn't take into
+	 * account that there could be more than one or several dozen {@link Shadow stub} interfaces, despite the fact that
+	 * they're all stored in a package designed specifically for the "general" implementation (not for "extended"). This
+	 * error could lead to the fact that, in the future, there'll be more classes in the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} alone than in the others (the approximate number
+	 * is estimated at 40-50 or more). This is a problem because 1.) it contradicts the original concept of packages in
+	 * the Java programming language, and 2.) it contradicts the original basis for which these particular classes were
+	 * combined into {@link com.github.justhm228.jlatenter.latent this particular package}. And in order to solve this
+	 * problem it was decided to move all {@link Shadow stub} interfaces from the
+	 * {@link com.github.justhm228.jlatenter.latent "general" package} to a specially created
+	 * {@link com.github.justhm228.jlatenter.latent.stub stub} subpackage. But in order to maintain backward
+	 * compatibility, it was decided not to move all the classes in the usual sense of the word, but simply copy them
+	 * there and inherit them from the previous ones, and mark the previous ones as {@link Deprecated deprecated}.
+	 * Further use of these {@link Deprecated deprecated} classes in newer code is highly discouraged, because
+	 * maintaining backward compatibility with one single pre-release 0.1-build.1 isn't such a priority, which means
+	 * that in one of the future releases these classes can be removed at any time, but this isn't yet guaranteed.
 	 */
 	@AvailableSince("0.1-build.1")
 	@NonExtendable() // <-- Shouldn't be implemented!
 	@Blocking() // <-- Potentially blocking context!
 	@Contract() // <-- "pure" is unknown
 	@Shadow() // <-- It's just a stub method
-	@SuppressWarnings("unused")
+	@Deprecated(since = "0.1-build.2")
 	void stop() throws Error, LatentException;
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Buildable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Buildable.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+
+@AvailableSince("0.1-build.2")
+@NonExtendable()
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public non-sealed interface Buildable<T extends Buildable<T>>
+		extends com.github.justhm228.jlatenter.latent.Buildable<T> {
+
+	@AvailableSince("0.1-build.2")
+	@NonExtendable()
+	@NonBlocking()
+	@Contract(value = " -> _", pure = true)
+	@SuppressWarnings("unused")
+	static @NotNull(exception = NullPointerException.class) Class<XBuildable> buildX() throws Error {
+
+		return XBuildable.class;
+	}
+
+	@AvailableSince("0.1-build.2")
+	@NonExtendable()
+	@NonBlocking()
+	@Contract(value = " -> _", pure = true)
+	@SuppressWarnings("unused")
+	static @NotNull(exception = NullPointerException.class) Class<SelfBuildable> buildSelf() throws Error {
+
+		return SelfBuildable.class;
+	}
+
+	@AvailableSince("0.1-build.2")
+	@NonExtendable()
+	@NonBlocking()
+	@Contract(value = " -> _", pure = true)
+	@SuppressWarnings("unused")
+	static @NotNull(exception = NullPointerException.class) Class<GenericBuildable> buildGeneric() throws Error {
+
+		return GenericBuildable.class;
+	}
+
+	@AvailableSince("0.1-build.2")
+	@NonExtendable()
+	@NonBlocking()
+	@Contract(value = " -> _", pure = true)
+	@SuppressWarnings("unused")
+	static @NotNull(exception = NullPointerException.class) Class<SelfBuildableC> buildSelfC() throws Error {
+
+		return SelfBuildableC.class;
+	}
+
+	@AvailableSince("0.1-build.2")
+	@NonExtendable()
+	@NonBlocking()
+	@Contract(value = " -> _", pure = true)
+	@SuppressWarnings("unused")
+	static @NotNull(exception = NullPointerException.class) Class<GenericBuildableC> buildGenericC() throws Error {
+
+		return GenericBuildableC.class;
+	}
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Drawable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Drawable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #draw() draw}()</code> method (returns <code>void</code>) which can be used
+ * in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Drawable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Drawable extends com.github.justhm228.jlatenter.latent.Drawable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Drawable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Drawable
+	 * @see com.github.justhm228.jlatenter.latent.Drawable#draw()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void draw() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Formattable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Formattable.java
@@ -22,27 +22,22 @@
  * SOFTWARE.
  */
 
-package com.github.justhm228.jlatenter.latent;
+package com.github.justhm228.jlatenter.latent.stub;
 
 import org.jetbrains.annotations.ApiStatus.*;
 import org.jetbrains.annotations.*;
 import java.lang.*;
 
-@AvailableSince("0.1-build.1")
+@AvailableSince("0.1-build.2")
 @NonExtendable()
-@Deprecated(since = "0.1-build.2")
-@SuppressWarnings({ "suppress", "warningToken" })
-public sealed interface Formattable<T extends Formattable<T>>
-		permits com.github.justhm228.jlatenter.latent.stub.Formattable, Formattable.SelfPrintable,
-		        Formattable.XPrintable, Formattable.SelfPrintableLN, Formattable.XPrintableLN,
-		        Formattable.SelfFormattable, Formattable.SelfFormatted, Formattable.SelfPrintableF,
-		        Formattable.XFormattable, Formattable.XPrintableF {
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public non-sealed interface Formattable<T extends Formattable<T>>
+		extends com.github.justhm228.jlatenter.latent.Formattable<T> {
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -51,11 +46,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return SelfPrintable.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -64,11 +58,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return XPrintable.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = " -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -77,11 +70,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return SelfPrintable.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -90,11 +82,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return XPrintable.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -105,11 +96,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return SelfFormattable.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -120,11 +110,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return SelfFormatted.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -134,11 +123,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return SelfPrintableF.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_, _ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -150,11 +138,10 @@ public sealed interface Formattable<T extends Formattable<T>>
 		return XFormattable.class;
 	}
 
-	@AvailableSince("0.1-build.1")
+	@AvailableSince("0.1-build.2")
 	@NonExtendable()
 	@NonBlocking()
 	@Contract(value = "_, _ -> _", pure = true)
-	@Deprecated(since = "0.1-build.2")
 	@SuppressWarnings("unused")
 	static @NotNull(exception = NullPointerException.class) Class<@NotNull(
 			exception = NullPointerException.class
@@ -164,148 +151,5 @@ public sealed interface Formattable<T extends Formattable<T>>
 	                     ) throws Error {
 
 		return XPrintableF.class;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface SelfPrintable extends Formattable<SelfPrintable> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void print() throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface XPrintable extends Formattable<XPrintable> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void print(final Object sequence) throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface SelfPrintableLN extends Formattable<SelfPrintableLN> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void println() throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface XPrintableLN extends Formattable<XPrintableLN> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void println(final Object sequence) throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface SelfFormattable extends Formattable<SelfFormattable> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void format(final Object... args) throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface SelfFormatted extends Formattable<SelfFormatted> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract(value = "_ -> _", pure = true)
-		@Shadow()
-		@SuppressWarnings("unused")
-		String formatted(final Object... args) throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface SelfPrintableF extends Formattable<SelfPrintableF> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void printf(final Object... args) throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonExtendable()
-	@Blocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface XFormattable extends Formattable<XFormattable> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void format(final Object sequence, final Object... args) throws Error, LatentException;
-	}
-
-	@AvailableSince("0.1-build.1")
-	@NonBlocking()
-	@FunctionalInterface()
-	@Shadow()
-	non-sealed interface XPrintableF extends Formattable<XPrintableF> {
-
-		@AvailableSince("0.1-build.1")
-		@NonExtendable()
-		@Blocking()
-		@Contract()
-		@Shadow()
-		@SuppressWarnings("unused")
-		void printf(final Object sequence, final Object... args) throws Error, LatentException;
 	}
 }

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Forwardable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Forwardable.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #forward() forward}()</code> method (returns <code>void</code>) which can be
+ * used in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Forwardable extends com.github.justhm228.jlatenter.latent.Forwardable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Forwardable
+	 * @see Shadow
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void forward() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Gettable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Gettable.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #get() get}()</code> method (returns <code>void</code>) which can be used in
+ * {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Gettable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Gettable extends com.github.justhm228.jlatenter.latent.Gettable {
+
+	// TODO: 30.10.2023 Expand this interface with other methods (like Formattable, Buildable, Puttable):
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Gettable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Gettable
+	 * @see com.github.justhm228.jlatenter.latent.Gettable#get()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract(" -> _") // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	Object get() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Paintable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Paintable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #paint() paint}()</code> method (returns <code>void</code>) which can be used
+ * in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Paintable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Paintable extends com.github.justhm228.jlatenter.latent.Paintable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Paintable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Paintable
+	 * @see com.github.justhm228.jlatenter.latent.Paintable#paint()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void paint() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Pausable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Pausable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #pause() pause}()</code> method (returns <code>void</code>) which can be used
+ * in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Pausable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Pausable extends com.github.justhm228.jlatenter.latent.Pausable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Pausable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Pausable
+	 * @see com.github.justhm228.jlatenter.latent.Pausable#pause()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void pause() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Puttable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Puttable.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.Shadow;
+import com.github.justhm228.jlatenter.latent.Latent;
+import com.github.justhm228.jlatenter.latent.LatentException;
+
+/**
+ * Just a stub interface with <code>{@link #put() put}()</code> method (returns <code>void</code>) which can be used in
+ * {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Puttable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Puttable extends com.github.justhm228.jlatenter.latent.Puttable {
+
+	// TODO: 30.10.2023 Expand this interface with other methods (like Formattable, Buildable, Gettable):
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Puttable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Puttable
+	 * @see com.github.justhm228.jlatenter.latent.Puttable#put()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void put() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Renderable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Renderable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #render() render}()</code> method (returns <code>void</code>) which can be
+ * used in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Renderable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Renderable extends com.github.justhm228.jlatenter.latent.Renderable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Renderable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Renderable
+	 * @see com.github.justhm228.jlatenter.latent.Renderable#render()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // It's just a stub method
+	@Override()
+	void render() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Startable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Startable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #start() start}()</code> method (returns <code>void</code>) which can be used
+ * in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Startable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Startable extends com.github.justhm228.jlatenter.latent.Startable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Startable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Startable
+	 * @see com.github.justhm228.jlatenter.latent.Startable#start()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // It's just a stub method
+	@Override()
+	void start() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Steppable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Steppable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #step() step}()</code> method (returns <code>void</code>) which can be used
+ * in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Steppable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Steppable extends com.github.justhm228.jlatenter.latent.Steppable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Steppable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Steppable
+	 * @see com.github.justhm228.jlatenter.latent.Steppable#step()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void step() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/Stoppable.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/Stoppable.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;
+import org.jetbrains.annotations.*;
+import java.lang.*;
+import com.github.justhm228.jlatenter.latent.*;
+
+/**
+ * Just a stub interface with <code>{@link #stop() stop}()</code> method (returns <code>void</code>) which can be used
+ * in {@link Latent latent typing}.
+ *
+ * @author JustHuman228
+ * @see Shadow
+ * @see com.github.justhm228.jlatenter.latent.Stoppable
+ * @since 0.1-build.2
+ */
+@AvailableSince("0.1-build.2")
+@NonExtendable() // <-- Shouldn't be implemented!
+@Blocking() // <-- Potentially blocking context!
+@FunctionalInterface()
+@Shadow() // <-- Just a stub interface
+@SuppressWarnings({ "suppress", "warningToken", "deprecation" })
+public interface Stoppable extends com.github.justhm228.jlatenter.latent.Stoppable {
+
+	/**
+	 * A stub method which can be called with {@link Latent latent typing}.
+	 *
+	 * @throws Error If something went wrong in the JVM.
+	 * @throws LatentException If something went wrong with {@link Latent latent typing} implementation.
+	 * @see Stoppable
+	 * @see Shadow
+	 * @see com.github.justhm228.jlatenter.latent.Stoppable
+	 * @see com.github.justhm228.jlatenter.latent.Stoppable#stop()
+	 * @since 0.1-build.2
+	 */
+	@AvailableSince("0.1-build.2")
+	@NonExtendable() // <-- Shouldn't be implemented!
+	@Blocking() // <-- Potentially blocking context!
+	@Contract() // <-- "pure" is unknown
+	@Shadow() // <-- It's just a stub method
+	@Override()
+	void stop() throws Error, LatentException;
+}

--- a/src/main/java/com/github/justhm228/jlatenter/latent/stub/package-info.java
+++ b/src/main/java/com/github/justhm228/jlatenter/latent/stub/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Chirkunov Egor
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+@AvailableSince("0.1-build.2")
+package com.github.justhm228.jlatenter.latent.stub;
+
+import org.jetbrains.annotations.ApiStatus.*;


### PR DESCRIPTION
Move all stub interfaces to another package.
Reason of these actions is described in
`@deprecated` tag in all javadocs of moved
classes.
