### PR TITLE
Document `package-info.java`

### DIFF
--- a/src/test/java/com/github/justhm228/jlatenter/test/package-info.java
+++ b/src/test/java/com/github/justhm228/jlatenter/test/package-info.java
@@ -22,6 +22,19 @@
  * SOFTWARE.
  */
 
+/**
+ * Stores all the unit tests of the JLatenter library.
+ *
+ * <p>
+ * <b>
+ * This package is considered internal, so the user can't and shouldn't access anything in this module, including
+ * Javadocs. All the Javadocs here provided only and only because why not, and not included in the global
+ * documentation.
+ * </b>
+ * </p>
+ *
+ * @since 0.1-build.1
+ */
 @AvailableSince("0.1-build.1")
 package com.github.justhm228.jlatenter.test;
 


### PR DESCRIPTION
Add a basic documentation for `package-info.java`
from `jlatenter.test` module. Nothing special.
